### PR TITLE
Fix for setuptools error 

### DIFF
--- a/package/Config.in.host
+++ b/package/Config.in.host
@@ -13,5 +13,6 @@ source "package/openocd/Config.in.host"
 source "package/sam-ba/Config.in.host"
 source "package/sunxi-tools/Config.in.host"
 source "package/uboot-tools/Config.in.host"
+source "package/python-setuptools/Config.in.host"
 
 endmenu

--- a/package/opencv/opencv.mk
+++ b/package/opencv/opencv.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-OPENCV_VERSION = 2.4.2
+OPENCV_VERSION = 2.4.4
 OPENCV_SITE    = http://downloads.sourceforge.net/project/opencvlibrary/opencv-unix/$(OPENCV_VERSION)
-OPENCV_SOURCE  = OpenCV-$(OPENCV_VERSION).tar.bz2
+OPENCV_SOURCE  = OpenCV-$(OPENCV_VERSION)a.tar.bz2
 OPENCV_INSTALL_STAGING = YES
 
 OPENCV_CONF_OPT += \
@@ -47,7 +47,7 @@ OPENCV_CONF_OPT += \
 	-DBUILD_opencv_nonfree=$(if $(BR2_PACKAGE_OPENCV_LIB_NONFREE),ON,OFF)   \
 	-DBUILD_opencv_objdetect=$(if $(BR2_PACKAGE_OPENCV_LIB_OBJDETECT),ON,OFF) \
 	-DBUILD_opencv_photo=$(if $(BR2_PACKAGE_OPENCV_LIB_PHOTO),ON,OFF)       \
-	-DBUILD_opencv_python=OFF                                               \
+	-DBUILD_opencv_python=ON                                               \
 	-DBUILD_opencv_stitching=$(if $(BR2_PACKAGE_OPENCV_LIB_STITCHING),ON,OFF) \
 	-DBUILD_opencv_ts=$(if $(BR2_PACKAGE_OPENCV_LIB_TS),ON,OFF)             \
 	-DBUILD_opencv_video=$(if $(BR2_PACKAGE_OPENCV_LIB_VIDEO),ON,OFF)       \

--- a/package/python-setuptools/Config.in.host
+++ b/package/python-setuptools/Config.in.host
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_HOST_PYTHON_SETUPTOOLS
+	bool "host python-setuptools"
+	help
+	  Download, build, install, upgrade, and uninstall Python packages.
+	
+	  http://pypi.python.org/pypi/setuptools

--- a/package/python-wiringpi2/Config.in
+++ b/package/python-wiringpi2/Config.in
@@ -1,6 +1,7 @@
 config BR2_PACKAGE_PYTHON_WIRINGPI2
 	bool "python-wiringpi2"
 	depends on BR2_PACKAGE_PYTHON
+	depends on BR2_PACKAGE_HOST_PYTHON_SETUPTOOLS
 	
 	help
 	  wiringPi C libraries and python bindings

--- a/package/python-wiringpi2/python-wiringpi2.mk
+++ b/package/python-wiringpi2/python-wiringpi2.mk
@@ -11,10 +11,9 @@ PYTHON_WIRINGPI2_SITE = https://github.com/WiringPi/WiringPi2-Python.git
 PYTHON_WIRINGPI2_SITE_METHOD = git
 
 PYTHON_WIRINGPI2_DEPENDENCIES = python
-#export PYTHONPATH=/home/razvan/rpi-buildroot/output/target/usr/lib/python2.7/site-packages/
+export PYTHONPATH=$(TARGET_DIR)/usr/lib/python$(PYTHON_VERSION_MAJOR)/site-packages/
 
 define PYTHON_WIRINGPI2_BUILD_CMDS
-	(export PYTHONPATH=$(TARGET_DIR)/usr/lib/python$(PYTHON_VERSION)/site-packages/)
 	(cd $(@D); swig -python wiringpi.i)
 	(cd $(@D); CC="$(TARGET_CC)" CFLAGS="$(TARGET_CFLAGS)" \
 		LDSHARED="$(TARGET_CROSS)gcc -shared" \


### PR DESCRIPTION
Hi,

I think I fixed it, tested with a clean buildroot. 

Also updated opencv to 2.4.4 ..

Note: now the python-wiringpi2 depends on host python-setuptools so it needs to be enabled first in nconfig in the host utilities section in order to get the option active in the target selection.

Cheers,

Razvan 
