### PR TITLE
Hearbleed vulnerability

### DIFF
--- a/package/openssl/openssl-004-heartbleed.patch
+++ b/package/openssl/openssl-004-heartbleed.patch
@@ -1,0 +1,132 @@
+From 96db9023b881d7cd9f379b0c154650d6c108e9a3 Mon Sep 17 00:00:00 2001
+From: "Dr. Stephen Henson" <steve@openssl.org>
+Date: Sun, 6 Apr 2014 00:51:06 +0100
+Subject: [PATCH 1/1] Add heartbeat extension bounds check.
+
+A missing bounds check in the handling of the TLS heartbeat extension
+can be used to reveal up to 64k of memory to a connected client or
+server.
+
+Thanks for Neel Mehta of Google Security for discovering this bug and to
+Adam Langley <agl@chromium.org> and Bodo Moeller <bmoeller@acm.org> for
+preparing the fix (CVE-2014-0160)
+---
+ CHANGES       |    9 +++++++++
+ ssl/d1_both.c |   26 ++++++++++++++++++--------
+ ssl/t1_lib.c  |   14 +++++++++-----
+ 3 files changed, 36 insertions(+), 13 deletions(-)
+
+#diff --git a/CHANGES b/CHANGES
+#index 0484456..08abe8d 100644
+#--- a/CHANGES
+#+++ b/CHANGES
+#@@ -4,6 +4,15 @@
+# 
+#  Changes between 1.0.1f and 1.0.1g [xx XXX xxxx]
+# 
+#+  *) A missing bounds check in the handling of the TLS heartbeat extension
+#+     can be used to reveal up to 64k of memory to a connected client or
+#+     server.
+#+
+#+     Thanks for Neel Mehta of Google Security for discovering this bug and to
+#+     Adam Langley <agl@chromium.org> and Bodo Moeller <bmoeller@acm.org> for
+#+     preparing the fix (CVE-2014-0160)
+#+     [Adam Langley, Bodo Moeller]
+#+
+#   *) Fix for the attack described in the paper "Recovering OpenSSL
+#      ECDSA Nonces Using the FLUSH+RELOAD Cache Side-channel Attack"
+#      by Yuval Yarom and Naomi Benger. Details can be obtained from:
+diff --git a/ssl/d1_both.c b/ssl/d1_both.c
+index 7a5596a..2e8cf68 100644
+--- a/ssl/d1_both.c
++++ b/ssl/d1_both.c
+@@ -1459,26 +1459,36 @@ dtls1_process_heartbeat(SSL *s)
+ 	unsigned int payload;
+ 	unsigned int padding = 16; /* Use minimum padding */
+ 
+-	/* Read type and payload length first */
+-	hbtype = *p++;
+-	n2s(p, payload);
+-	pl = p;
+-
+ 	if (s->msg_callback)
+ 		s->msg_callback(0, s->version, TLS1_RT_HEARTBEAT,
+ 			&s->s3->rrec.data[0], s->s3->rrec.length,
+ 			s, s->msg_callback_arg);
+ 
++	/* Read type and payload length first */
++	if (1 + 2 + 16 > s->s3->rrec.length)
++		return 0; /* silently discard */
++	hbtype = *p++;
++	n2s(p, payload);
++	if (1 + 2 + payload + 16 > s->s3->rrec.length)
++		return 0; /* silently discard per RFC 6520 sec. 4 */
++	pl = p;
++
+ 	if (hbtype == TLS1_HB_REQUEST)
+ 		{
+ 		unsigned char *buffer, *bp;
++		unsigned int write_length = 1 /* heartbeat type */ +
++					    2 /* heartbeat length */ +
++					    payload + padding;
+ 		int r;
+ 
++		if (write_length > SSL3_RT_MAX_PLAIN_LENGTH)
++			return 0;
++
+ 		/* Allocate memory for the response, size is 1 byte
+ 		 * message type, plus 2 bytes payload length, plus
+ 		 * payload, plus padding
+ 		 */
+-		buffer = OPENSSL_malloc(1 + 2 + payload + padding);
++		buffer = OPENSSL_malloc(write_length);
+ 		bp = buffer;
+ 
+ 		/* Enter response type, length and copy payload */
+@@ -1489,11 +1499,11 @@ dtls1_process_heartbeat(SSL *s)
+ 		/* Random padding */
+ 		RAND_pseudo_bytes(bp, padding);
+ 
+-		r = dtls1_write_bytes(s, TLS1_RT_HEARTBEAT, buffer, 3 + payload + padding);
++		r = dtls1_write_bytes(s, TLS1_RT_HEARTBEAT, buffer, write_length);
+ 
+ 		if (r >= 0 && s->msg_callback)
+ 			s->msg_callback(1, s->version, TLS1_RT_HEARTBEAT,
+-				buffer, 3 + payload + padding,
++				buffer, write_length,
+ 				s, s->msg_callback_arg);
+ 
+ 		OPENSSL_free(buffer);
+diff --git a/ssl/t1_lib.c b/ssl/t1_lib.c
+index b82fada..bddffd9 100644
+--- a/ssl/t1_lib.c
++++ b/ssl/t1_lib.c
+@@ -2588,16 +2588,20 @@ tls1_process_heartbeat(SSL *s)
+ 	unsigned int payload;
+ 	unsigned int padding = 16; /* Use minimum padding */
+ 
+-	/* Read type and payload length first */
+-	hbtype = *p++;
+-	n2s(p, payload);
+-	pl = p;
+-
+ 	if (s->msg_callback)
+ 		s->msg_callback(0, s->version, TLS1_RT_HEARTBEAT,
+ 			&s->s3->rrec.data[0], s->s3->rrec.length,
+ 			s, s->msg_callback_arg);
+ 
++	/* Read type and payload length first */
++	if (1 + 2 + 16 > s->s3->rrec.length)
++		return 0; /* silently discard */
++	hbtype = *p++;
++	n2s(p, payload);
++	if (1 + 2 + payload + 16 > s->s3->rrec.length)
++		return 0; /* silently discard per RFC 6520 sec. 4 */
++	pl = p;
++
+ 	if (hbtype == TLS1_HB_REQUEST)
+ 		{
+ 		unsigned char *buffer, *bp;
+-- 
+1.7.9.5
+


### PR DESCRIPTION
This software uses openssl-1.0.1f, which is vulnerable to the Heartbleed bug.

The patch file applies the fix for it.  I found it easier than bumping the openssl version number (it did not compile).
