### PR TITLE
Update old route on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ Now format the boot partition as FAT 16
 	mkdir -p /media/boot
 	mount /dev/sdx1 /media/boot
 
-You will need to copy all the files in *output/target/boot* to your *boot*
+You will need to copy all the files in *output/images/boot* to your *boot*
 partition.
 
 	# run the following as root
-	cp output/target/boot/* /media/boot
+	cp output/images/boot/* /media/boot
 	umount /media/boot
 
 The second (rootfs) can be as big as you want, but with a 200 MB minimum,


### PR DESCRIPTION
Seems like manual deploying instructions on README.md for copying the boot partition files was pointing to a wrong/old route ( output/target/boot/ ). Checking the scripts I find the correct route should be 'output/images/boot/'.
