### PR TITLE
Added missing 'p' for RPi mksdcard partitions.

### DIFF
--- a/board/raspberrypi/mksdcard
+++ b/board/raspberrypi/mksdcard
@@ -142,8 +142,8 @@ sleep 1
 
 section "Formatting partitions..."
 
-${MKFS_VFAT} -F 16 -n BOOT -I "${SDCARD}1" || exit 1
-${MKFS_EXT4} -F -q -L rootfs "${SDCARD}2" || exit 1
+${MKFS_VFAT} -F 16 -n BOOT -I "${SDCARD}p1" || exit 1
+${MKFS_EXT4} -F -q -L rootfs "${SDCARD}p2" || exit 1
 
 # prepare to fill partitions
 
@@ -153,7 +153,7 @@ ${MKDIR} .mnt
 
 section "Populating boot partition..."
 
-${MOUNT} "${SDCARD}1" .mnt || exit 2
+${MOUNT} "${SDCARD}p1" .mnt || exit 2
 ${CP} ${OUTPUT_PREFIX}images/rpi-firmware/bootcode.bin .mnt
 ${CP} ${OUTPUT_PREFIX}images/rpi-firmware/fixup.dat .mnt
 ${CP} ${OUTPUT_PREFIX}images/rpi-firmware/start.elf .mnt
@@ -166,7 +166,7 @@ ${UMOUNT} .mnt
 
 section "Populating rootfs partition..."
 
-${MOUNT} "${SDCARD}2" .mnt || exit 2
+${MOUNT} "${SDCARD}p2" .mnt || exit 2
 ${TAR} -xpsf ${OUTPUT_PREFIX}images/rootfs.tar -C .mnt
 ${SYNC}
 ${UMOUNT} .mnt


### PR DESCRIPTION
The 'p' prefix was missing when referencing the partitions. It was causing a compilation error in the **Raspberry Pi** `mksdcard` script.
