### PR TITLE
Make check for mmcblk work on dash (Ubuntu 15.04)

### DIFF
--- a/board/raspberrypi/mksdcard
+++ b/board/raspberrypi/mksdcard
@@ -141,7 +141,7 @@ sleep 1
 # format partitions
 
 section "Formatting partitions..."
-if [[ "${SDCARD}" = "/dev/mmcblk"* ]]; then
+if [ `echo ${SDCARD} | grep -c "/dev/mmcblk"` -eq 1 ]; then
     SDCARDP="${SDCARD}p"
 else
     SDCARDP=${SDCARD}


### PR DESCRIPTION
The check for mmcblk does not work on Ubuntu 15.04 (uses dash as /bin/sh). Followed the suggestions in https://wiki.ubuntu.com/DashAsBinSh and made this work for many shells.

Tested on Ubuntu 15.04 with dash, bash, ash and ksh
