### PR TITLE
update RPI-FIRMWARE_VERSION to valid tag

### DIFF
--- a/package/rpi-firmware/rpi-firmware.mk
+++ b/package/rpi-firmware/rpi-firmware.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_FIRMWARE_VERSION = 1.20160225
+RPI_FIRMWARE_VERSION = 1.20160309
 RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))
 RPI_FIRMWARE_LICENSE = BSD-3c
 RPI_FIRMWARE_LICENSE_FILES = boot/LICENCE.broadcom


### PR DESCRIPTION
tag  1.20160225 does not exist at https://github.com/raspberrypi/firmware. this caused my build to fail. 
Builds with 1.20160309 as the firmware version
